### PR TITLE
Added support for custom components in theme-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,5 +83,9 @@ You can configure some options in `element-theme` by putting it in package.json:
 }
 ```
 
+## Customization
+Create your own css files inside of folder `theme-in/custom`.
+It will be compiled to `theme-out`.
+
 ## License
 MIT

--- a/lib/task.js
+++ b/lib/task.js
@@ -36,13 +36,17 @@ exports.build = function (opts) {
   var stream
   var components
   var cssFiles = '*'
+  var customCssFiles = '*'
 
   if (config.components) {
     components = config.components.concat(['base'])
     cssFiles = '{' + components.join(',') + '}'
   }
 
-  stream = gulp.src([opts.config || config.config, path.resolve(config.themePath, './src/' + cssFiles + '.css')])
+  var componentsPath = path.resolve(config.themePath, './src/' + cssFiles + '.css')
+  var customPath = path.resolve(config.themePath, './custom/' + customCssFiles + '.css')
+
+  stream = gulp.src([opts.config || config.config, componentsPath, customPath])
     .pipe(replaceVars(opts.config))
     .pipe(postcss([salad(opts.browsers), themeize()]))
     .pipe((opts.minimize || config.minimize) ? cssmin({showLog: false}) : nop())


### PR DESCRIPTION
Added support for `custom` folder in `theme-in`.
One of next steps can be extending watcher to include new folder..